### PR TITLE
Remove phishing link

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -82,7 +82,6 @@ const experiments = [
   {
     name: "stats360.co",
     description: "(now broken) reverse engineered Life360 dashboard",
-    link: "https://stats360.co",
   },
   {
     name: "whoopkit",


### PR DESCRIPTION
Now that stats360 is deprecated, the domain was taken over by a malicious entity. https://wheregoes.com/trace/20243936075/
![image](https://github.com/user-attachments/assets/5ae55c3b-4872-4c9a-af6a-40cce0f41c31)
